### PR TITLE
Parsing of segment:offset jmp instructions found in 16 bit real mode

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -502,13 +502,14 @@ module.exports = grammar({
       optional($.operand_prefix),
       choice(
         $.register,
+        $.segment_offset,
         $.effective_address,
         $._expression,
       ),
     ),
 
     operand_prefix: $ => seq(
-      optional(ci('STRICT')),
+      optional(choice(...['STRICT', 'SHORT'].map(ci))),
       $.size_hint,
       // YYY: `optional(choice('FAR', ..))`?
     ),
@@ -557,6 +558,23 @@ module.exports = grammar({
       // YYY: could do with better mib expression handling
       optional(seq(',', $._expression)),
       ']',
+    ),
+
+    segment_offset: $ => seq(
+      // YYY: Specific to jump instructions in 16 bit mode, could be revised
+      //      to only be valid for jump instructions. Also this is a little hacky
+      //      to avoid conflicts
+      field('segment', 
+            seq(choice(
+                  ...['CS', 'DS', 'SS', 'ES', 'FS', 'GS'].map(ci), 
+                  $.binary_expression, 
+                  $.word, 
+                  $.number_literal,
+                  $.preproc_expression,
+                  $.parenthesized_expression
+               ), ':')
+      ),
+      $._expression,
     ),
 
 //  #region constant

--- a/grammar.js
+++ b/grammar.js
@@ -509,8 +509,8 @@ module.exports = grammar({
     ),
 
     operand_prefix: $ => seq(
-      optional(choice(...['STRICT', 'SHORT'].map(ci))),
-      $.size_hint,
+      optional(ci('STRICT')),
+      choice($.size_hint, ci('SHORT')),
       // YYY: `optional(choice('FAR', ..))`?
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3528,6 +3528,10 @@
             },
             {
               "type": "SYMBOL",
+              "name": "segment_offset"
+            },
+            {
+              "type": "SYMBOL",
               "name": "effective_address"
             },
             {
@@ -3545,8 +3549,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "PATTERN",
-              "value": "[sS][tT][rR][iI][cC][tT]"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[sS][tT][rR][iI][cC][tT]"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "[sS][hH][oO][rR][tT]"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -4658,6 +4671,77 @@
         {
           "type": "STRING",
           "value": "]"
+        }
+      ]
+    },
+    "segment_offset": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "segment",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "PATTERN",
+                    "value": "[cC][sS]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[dD][sS]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[sS][sS]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[eE][sS]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[fF][sS]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[gG][sS]"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "binary_expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "word"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "number_literal"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "preproc_expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "parenthesized_expression"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": ":"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
         }
       ]
     },
@@ -6206,3 +6290,4 @@
   "inline": [],
   "supertypes": []
 }
+

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3549,17 +3549,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "[sS][tT][rR][iI][cC][tT]"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "[sS][hH][oO][rR][tT]"
-                }
-              ]
+              "type": "PATTERN",
+              "value": "[sS][tT][rR][iI][cC][tT]"
             },
             {
               "type": "BLANK"
@@ -3567,8 +3558,17 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "size_hint"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "size_hint"
+            },
+            {
+              "type": "PATTERN",
+              "value": "[sS][hH][oO][rR][tT]"
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -708,24 +708,38 @@
           }
         },
         {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "PATTERN",
-            "value": "[^(]"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "value",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "PATTERN",
-              "value": "(\\\\\\r?\\n|.)*"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "IMMEDIATE_TOKEN",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^(]"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "value",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "(\\\\\\r?\\n|[^;\\n])*"
+                    },
+                    "named": true,
+                    "value": "preproc_arg"
+                  }
+                }
+              ]
             },
-            "named": true,
-            "value": "preproc_arg"
-          }
+            {
+              "type": "STRING",
+              "value": "\n"
+            }
+          ]
         }
       ]
     },
@@ -867,7 +881,7 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "(\\\\\\r?\\n|.)*"
+              "value": "(\\\\\\r?\\n|[^;\\n])*"
             },
             "named": true,
             "value": "preproc_arg"
@@ -4686,30 +4700,6 @@
               {
                 "type": "CHOICE",
                 "members": [
-                  {
-                    "type": "PATTERN",
-                    "value": "[cC][sS]"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[dD][sS]"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[sS][sS]"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[eE][sS]"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[fF][sS]"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[gG][sS]"
-                  },
                   {
                     "type": "SYMBOL",
                     "name": "binary_expression"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1860,6 +1860,10 @@
           "named": true
         },
         {
+          "type": "segment_offset",
+          "named": true
+        },
+        {
           "type": "string_literal",
           "named": true
         },
@@ -3371,6 +3375,108 @@
     "type": "register",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "segment_offset",
+    "named": true,
+    "fields": {
+      "segment": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": ":",
+            "named": false
+          },
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "preproc_expression",
+            "named": true
+          },
+          {
+            "type": "word",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "call_syntax_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "grouped_expression",
+          "named": true
+        },
+        {
+          "type": "line_here_token",
+          "named": true
+        },
+        {
+          "type": "number_literal",
+          "named": true
+        },
+        {
+          "type": "packed_bcd_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "preproc_expression",
+          "named": true
+        },
+        {
+          "type": "register",
+          "named": true
+        },
+        {
+          "type": "section_here_token",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "word",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "size_hint",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2057,7 +2057,7 @@
       },
       "value": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "preproc_arg",
@@ -3933,6 +3933,10 @@
     "type": "word",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "\n",
+    "named": false
   },
   {
     "type": "!",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1884,7 +1884,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "size_hint",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -86,11 +87,6 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
-
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -130,38 +126,13 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -175,17 +146,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -206,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -216,7 +176,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -224,7 +184,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}
@@ -237,15 +197,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/macros.txt
+++ b/test/corpus/macros.txt
@@ -11,8 +11,7 @@ header guard
     (word)
     (body
       (preproc_def
-        (word)
-        (preproc_arg))
+        (word))
       (comment)))
   (comment))
 ===

--- a/test/corpus/source_line.txt
+++ b/test/corpus/source_line.txt
@@ -332,3 +332,25 @@ floating point
           (operand
             (register))))))
   (comment))
+
+===
+jump segment-offset
+===
+
+label:
+    jmp 0x0:0x7C00
+---
+
+(source_file
+  (source_line
+    (label
+      (word)))
+  (source_line
+    (instruction
+      (actual_instruction
+        (word)
+        (operands
+          (operand
+            (segment_offset
+              (number_literal)
+              (number_literal))))))))


### PR DESCRIPTION
Added node type for segment:offset operands. These operands are only supported in 16 bit real mode, and they don't allow registers to be supplied as the segment or offset, so my solution only takes into account numeric literals, labels, and other forms of expressions that are supported. This still passes the same test cases it did before, but fails the same one referenced in my comment in issue #4. 

This PR resolves #4. 